### PR TITLE
add support for maxsize directive

### DIFF
--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -56,6 +56,11 @@
 #                   but not before the scheduled rotation time (optional).
 #                   The default units are bytes, append k, M or G for kilobytes,
 #                   megabytes and gigabytes respectively.
+# maxsize         - The String maximum size a log file may be to be rotated;
+#                   When maxsize is used, both the size and timestamp of a log
+#                   file are considered for rotation.
+#                   The default units are bytes, append k, M or G for kilobytes,
+#                   megabytes and gigabytes respectively.
 # missingok       - A Boolean specifying whether logrotate should ignore missing
 #                   log files or issue an error (optional).
 # olddir          - A String path to a directory that rotated logs should be
@@ -145,6 +150,7 @@ define logrotate::rule(
   $maillast        = 'undef',
   $maxage          = 'undef',
   $minsize         = 'undef',
+  $maxsize         = 'undef',
   $missingok       = 'undef',
   $olddir          = 'undef',
   $postrotate      = 'undef',
@@ -314,6 +320,14 @@ define logrotate::rule(
     /^\d+[kMG]?$/: {}
     default: {
       fail("Logrotate::Rule[${name}]: minsize must match /\\d+[kMG]?/")
+    }
+  }
+
+  case "$maxsize" {
+    'undef': {}
+    /^\d+[kMG]?$/: {}
+    default: {
+      fail("Logrotate::Rule[${name}]: maxsize must match /\\d+[kMG]?/")
     }
   }
 

--- a/templates/rule.erb
+++ b/templates/rule.erb
@@ -28,7 +28,7 @@
 
   [
     'compresscmd', 'compressext', 'compressoptions', 'dateformat', 'extension',
-    'maxage', 'minsize', 'rotate', 'size', 'shredcycles', 'start',
+    'maxage', 'minsize', 'maxsize', 'rotate', 'size', 'shredcycles', 'start',
     'uncompresscmd'
   ].each do |key|
     value = scope.to_hash[key]


### PR DESCRIPTION
Adds support for the `maxsize` directive introduced in logrotate [3.8.1](https://github.com/logrotate/logrotate/blob/master/ChangeLog.md#381---2011-08-31)